### PR TITLE
fixes typo in wupper3 section

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -56,7 +56,7 @@
                             },
                             wupper3 = {
                                 key = 'c8f3d1d10b0d6389e39c3c3cb08adfa3123e821fd5bfd6262d2161d80ee4b06c',
-                                emotes = {'"wupper3.freifunk-troisdorf.de" port 53840'},
+                                remotes = {'"wupper3.freifunk-troisdorf.de" port 53840'},
                             },
                             wupper4 = {
                                 key = '5e7fa122990dbc34b8cae7ece2cd4ef919d3f8c23a674b7bbcf05bfebe6a6e8a',


### PR DESCRIPTION
```
                        wupper3 = {
                            key = 'c8f3d1d10b0d6389e39c3c3cb08adfa3123e821fd5bfd6262d2161d80ee4b06c',
                            before: emotes = {'"wupper3.freifunk-troisdorf.de" port 53840'},
                            After: remotes = {'"wupper3.freifunk-troisdorf.de" port 53840'},
```
